### PR TITLE
Fix Off-By-One error in column and row coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dephell = "^0.8.3"
 tess-locator = {path = "../tess-locator", develop = true}
 tess-ephem = {path = "../tess-ephem", develop = true}
 lightkurve = {path = "../lightkurve", develop = true}
+pytest-remotedata = "^0.3.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/tess_cloud/image.py
+++ b/src/tess_cloud/image.py
@@ -272,7 +272,9 @@ class TessImage:
     async def _find_pixel_offset(self, column: int, row: int) -> int:
         """Returns the byte offset of a specific pixel position."""
         data_offset = await self._find_data_offset(ext=self.data_ext)
-        pixel_offset = column + row * FFI_COLUMNS
+        # Subtract 1 from column and row because the byte location assumes zero-indexing,
+        # whereas the TESS convention is to address column and row number with one-indexing.
+        pixel_offset = (column - 1) + (row - 1) * FFI_COLUMNS
         return data_offset + BYTES_PER_PIX * pixel_offset
 
     async def _find_pixel_blocks(

--- a/src/tess_cloud/targetpixelfile.py
+++ b/src/tess_cloud/targetpixelfile.py
@@ -282,7 +282,14 @@ class TargetPixelFile:
 
         coldefs = fits.ColDefs(cols)
         hdu = fits.BinTableHDU.from_columns(coldefs)
+
+        # Set useful header keywords
         hdu.header["BJDREFI"] = 2457000
+        # Lightkurve relies on 1CRV5P and 2CRV5P to display column/row coordinates in plots
+        if "CORNER_COLUMN" in self._optional_column_data:
+            hdu.header["1CRV5P"] = self._optional_column_data["CORNER_COLUMN"][0]
+        if "CORNER_ROW" in self._optional_column_data:
+            hdu.header["2CRV5P"] = self._optional_column_data["CORNER_ROW"][0]
 
         return hdu
 


### PR DESCRIPTION
Over in #7, @jcsmithhere correctly pointed out that tess-cloud currently interprets column and row coordinates in the "0-based indexing" scheme.  This is inconsistent with the convention for the TESS mission, which is to use 1-based indexing for pixels.  As a result, cutouts produced by tess-cloud are consistently off by one pixel in both the column and the row direction.

This PR fixes the issue and adds a unit test which compares the fluxes returned by tess-cloud with those obtained via TessCut, which acts as an effective test to verify that column/row indexing is consistent with the convention used by TessCut.

Below I post a before/after example.  The example demonstrates how I reproduced the issue, and that the PR fixes the example shown.

## Behavior before this PR

<img width="699" alt="Screen Shot 2021-07-20 at 9 36 26 AM" src="https://user-images.githubusercontent.com/817669/126362241-ea168c46-e446-4872-99b9-9718addf1891.png">


## Behavior with this PR merged

<img width="697" alt="Screen Shot 2021-07-20 at 9 35 58 AM" src="https://user-images.githubusercontent.com/817669/126362214-380fe147-b45f-4d9e-aa6f-181c4de13a55.png">
