### PR TITLE
New decencies versions and improved pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-cloud"
-version = "0.5.dev"
+version = "0.5.0"
 description = "Analyze NASA TESS data in the cloud."
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>"]
@@ -14,15 +14,15 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-tess-locator = ">=0.5.0"
-tess-ephem = ">=0.3.0"
-lightkurve = ">=2.0.9"
-numpy = ">=1.19"
-astropy = ">=4.2"
+python = "^3.8"
+tess-locator = "^0.6"
+tess-ephem = "^0.4"
+lightkurve = "^2.3.0"
+numpy = "^1.23.0"
+astropy = "^5.2.0"
 aioboto3 = ">=9.0.0"
 diskcache = ">=5.2.1"
-tqdm = ">=4.58.0"
+tqdm = ">=4.51.0"
 aiohttp = ">=3.7.4"
 nest-asyncio = ">=1.5.1"
 s3fs = ">=0.5.2"

--- a/src/tess_cloud/__init__.py
+++ b/src/tess_cloud/__init__.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-__version__ = "0.5.dev"
+__version__ = "0.5.0"
 
 # Configure logging
 log = logging.getLogger(__name__)

--- a/src/tess_cloud/asteroid_pipeline.py
+++ b/src/tess_cloud/asteroid_pipeline.py
@@ -8,7 +8,7 @@ import numpy as np
 from tess_ephem import ephem
 
 from . import cutout_asteroid, __version__
-from .targetpixelfile import TargetPixelFile, TPF_OPTIONAL_COLUMNS
+from .targetpixelfile import TargetPixelFile
 
 
 class SimpleAsteroidPipeline:

--- a/src/tess_cloud/cutout.py
+++ b/src/tess_cloud/cutout.py
@@ -4,8 +4,6 @@ from typing import Optional
 from tess_locator import locate, TessCoordList
 from tess_ephem import ephem
 
-from astropy.time import Time
-
 from .image import TessImage
 from .imagelist import list_images, TessImageList
 from .targetpixelfile import TargetPixelFile

--- a/src/tess_cloud/image.py
+++ b/src/tess_cloud/image.py
@@ -21,7 +21,6 @@ import backoff
 
 from . import MAX_CONCURRENT_DOWNLOADS, MAX_CONCURRENT_CUTOUTS, MAX_TCP_CONNECTIONS
 from . import USER_AGENT, TESS_S3_BUCKET, log
-from .manifest import get_s3_uri
 
 # FITS standard specifies that header and data units
 # shall be a multiple of 2880 bytes long.

--- a/src/tess_cloud/manifest.py
+++ b/src/tess_cloud/manifest.py
@@ -91,6 +91,6 @@ def list_images(sector: int, camera: int = None, ccd: int = None):
         ccd = r"\d"  # regex
     ffi_files = _load_ffi_manifest()
     mask = ffi_files.path.str.match(
-        fr".*tess(\d+)-s{sector:04d}-{camera}-{ccd}-\d+-._ffic.fits"
+        rf".*tess(\d+)-s{sector:04d}-{camera}-{ccd}-\d+-._ffic.fits"
     )
     return ffi_files[mask].path.str.split("/").str[-1].values.tolist()

--- a/src/tess_cloud/spoc.py
+++ b/src/tess_cloud/spoc.py
@@ -111,7 +111,7 @@ def _list_spoc_images_mast(sector, camera=r"\d", ccd=r"\d"):
     # try:
     df = _get_mast_bundle(sector=sector)
     mask = df.url.str.match(
-        fr".*tess(\d+)-s{sector:04d}-{camera}-{ccd}-\d+-._ffic.fits"
+        rf".*tess(\d+)-s{sector:04d}-{camera}-{ccd}-\d+-._ffic.fits"
     )
     return TessImageList([TessImage(url) for url in df[mask].url.values])
     # except HTTPError:
@@ -122,7 +122,7 @@ def _list_spoc_images_aws(sector, camera=r"\d", ccd=r"\d"):
     """Returns a list of the FFIs for a given sector/camera/ccd."""
     ffi_files = _load_ffi_manifest()
     mask = ffi_files.path.str.match(
-        fr".*tess(\d+)-s{sector:04d}-{camera}-{ccd}-\d+-._ffic.fits"
+        rf".*tess(\d+)-s{sector:04d}-{camera}-{ccd}-\d+-._ffic.fits"
     )
     return TessImageList(
         [TessImage("s3://stpubdata/" + x) for x in ffi_files[mask].path.values]

--- a/src/tess_cloud/targetpixelfile.py
+++ b/src/tess_cloud/targetpixelfile.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from typing import Optional
 
 import numpy as np
-from numpy import array, ndarray
+from numpy import ndarray
 
 from astropy.wcs import WCS
 from astropy.io import fits

--- a/tests/test_cutout.py
+++ b/tests/test_cutout.py
@@ -9,32 +9,39 @@ from tess_cloud import TessImage, list_images
 
 
 def test_cutout():
-    """Test basic features of RemoteTessImage."""
-    url = "s3://stpubdata/tess/public/ffi/s0012/2019/142/2-1/tess2019142115932-s0012-2-1-0144-s_ffic.fits"
-    img = TessImage(url=url)
+    """Test basic features of RemoteTessImage.
+    Compares data against loading an image with astropy.io.fits from MAST
+    """
+    url_s3 = "s3://stpubdata/tess/public/ffi/s0012/2019/142/2-1/tess2019142115932-s0012-2-1-0144-s_ffic.fits"
+    url_mast = "https://archive.stsci.edu/missions/tess/ffi/s0012/2019/142/2-1/tess2019142115932-s0012-2-1-0144-s_ffic.fits"
+    img = TessImage(url=url_s3)
+    mast_data = fits.getdata(url_mast)
     # Can we retrieve the first FITS header keyword? (SIMPLE)
     assert img.read_block(0, 6) == b"SIMPLE"
     assert img.read_block(8, 1) == b"="
     # assert img.read_blocks([(0, 6), (8, 1)]) == [b"SIMPLE", b"="]
     # Can we find the correct start position of the data for extenions 0 and 1?
     assert asyncio.run(img._find_data_offset(ext=0)) == 2880
-    assert asyncio.run(img._find_data_offset(ext=1)) == 23040
+    assert asyncio.run(img._find_data_offset(ext=1)) == 20160
     # By tess convention, the very first pixel has column=1 and row=1
-    assert asyncio.run(img._find_pixel_offset(column=1, row=1)) == 23040
+    assert asyncio.run(img._find_pixel_offset(column=1, row=1)) == 20160
     assert asyncio.run(img._find_pixel_blocks(column=1, row=1, shape=(1, 1))) == [
-        (23040, 4)
+        (20160, 4)
     ]
+    # TESSImage.cutout returns a numpy.float64, astropy fits gives numpy.float32
     # Corner pixel
-    assert img.cutout(column=1, row=1, shape=(1, 1)).flux.round(7) == 0.0941298
+    assert img.cutout(column=1, row=1, shape=(1, 1)).flux.astype(np.float32).round(
+        7
+    ) == mast_data[0, 0].reshape((1, 1)).round(7)
     # First three pixels of the first row
     assert (
-        img.cutout(column=2, row=1, shape=(3, 1)).flux.round(7)
-        == np.array([0.0941298, -0.0605419, 0.0106343])
+        img.cutout(column=2, row=1, shape=(3, 1)).flux.astype(np.float32).round(7)
+        == mast_data[0, :3].reshape((1, 3)).round(7)
     ).all()
     # First three pixels of the first column
     assert (
-        img.cutout(column=2, row=2, shape=(1, 3)).flux.round(7)
-        == np.array([[-0.0605419], [0.0327947], [-0.0278026]])
+        img.cutout(column=2, row=2, shape=(1, 3)).flux.astype(np.float32).round(7)
+        == mast_data[:3, 1].reshape((3, 1)).round(7)
     ).all()
 
 


### PR DESCRIPTION
This updates dependencies to:

- lightkurve = "^2.3.0"
- numpy = "^1.23.0"
- astropy = "^5.2.0"

Improves testing cutout method by comparing FITS file values against loading the file with `astropy.io.fits` instead of hardcoded values